### PR TITLE
fix chromium only if possible

### DIFF
--- a/odroid-tweaks
+++ b/odroid-tweaks
@@ -8,8 +8,12 @@ if [ -f /sys/class/net/eth0/queues/rx-0/rps_cpus ]; then
 	echo f > /sys/class/net/eth0/queues/rx-0/rps_cpus
 fi
 
-# fix chromium
-mv /usr/lib/chromium-browser/libEGL.so /usr/lib/chromium-browser/libEGL.so.org
-mv /usr/lib/chromium-browser/libGLESv2.so /usr/lib/chromium-browser/libGLESv2.so.org
-ln -s /usr/lib/arm-linux-gnueabihf/mali-egl/libmali.so /usr/lib/chromium-browser/libEGL.so
-ln -s /usr/lib/arm-linux-gnueabihf/mali-egl/libmali.so /usr/lib/chromium-browser/libGLESv2.so
+# fix chromium if possible
+if [ -e "/usr/lib/chromium-browser/libEGL.so" -a -e "/usr/lib/arm-linux-gnueabihf/mali-egl/libmali.so" ]; then
+	mv /usr/lib/chromium-browser/libEGL.so /usr/lib/chromium-browser/libEGL.so.org
+	ln -s /usr/lib/arm-linux-gnueabihf/mali-egl/libmali.so /usr/lib/chromium-browser/libEGL.so
+fi
+if [ -e "/usr/lib/chromium-browser/libGLESv2.so" -a -e "/usr/lib/arm-linux-gnueabihf/mali-egl/libmali.so" ]; then
+	mv /usr/lib/chromium-browser/libGLESv2.so /usr/lib/chromium-browser/libGLESv2.so.org
+	ln -s /usr/lib/arm-linux-gnueabihf/mali-egl/libmali.so /usr/lib/chromium-browser/libGLESv2.so
+fi


### PR DESCRIPTION
Because I don't have chromium I get this error with systemd :  
root@odroid:~# systemctl status odroid-tweaks.service
● odroid-tweaks.service - ODROID Specific System Tweaks
   Loaded: loaded (/etc/systemd/system/odroid-tweaks.service; enabled; vendor preset: enabled)
   Active: failed (Result: exit-code) since jeu. 2018-05-10 20:16:50 EDT; 1s ago
  Process: 16895 ExecStart=/bin/odroid-tweaks (code=exited, status=1/FAILURE)

mai 10 20:16:50 odroid systemd[1]: Starting ODROID Specific System Tweaks...
mai 10 20:16:50 odroid odroid-tweaks[16895]: mv: cannot stat '/usr/lib/chromium-browser/libEGL.so': No such file or directory
mai 10 20:16:50 odroid odroid-tweaks[16895]: mv: cannot stat '/usr/lib/chromium-browser/libGLESv2.so': No such file or directory
mai 10 20:16:50 odroid odroid-tweaks[16895]: ln: failed to create symbolic link '/usr/lib/chromium-browser/libEGL.so': No such file or directory
mai 10 20:16:50 odroid odroid-tweaks[16895]: ln: failed to create symbolic link '/usr/lib/chromium-browser/libGLESv2.so': No such file or directory
mai 10 20:16:50 odroid systemd[1]: odroid-tweaks.service: Control process exited, code=exited status=1
mai 10 20:16:50 odroid systemd[1]: Failed to start ODROID Specific System Tweaks.                                                                                                                                   
mai 10 20:16:50 odroid systemd[1]: odroid-tweaks.service: Unit entered failed state.
mai 10 20:16:50 odroid systemd[1]: odroid-tweaks.service: Failed with result 'exit-code'.

This little patch fix the issue.

Thanks !